### PR TITLE
ci: Re-enable code coverage failure check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,3 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.txt
-          # TODO(thane): Re-enable once we make the repo public
-          fail_ci_if_error: false


### PR DESCRIPTION
This was only necessary while the repo was private.