### PR TITLE
Bump minimum Go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.18
+go 1.19
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.4


### PR DESCRIPTION
Go 1.18 is EOL and contains security vulnerabilities. CometBFT has also updated to use Go 1.19 at a minimum, as per cometbft/cometbft#360.