### PR TITLE
Bump minimum Go version to v1.20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.6.0
         with:
           args: --timeout 10m
-          version: v1.51.2
+          version: latest
           github-token: ${{ secrets.github_token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,3 +30,22 @@ issues:
 linters-settings:
   errcheck:
     check-blank: true
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/cometbft
+          - github.com/syndtr/goleveldb/leveldb
+          - github.com/google/btree
+      test:
+        files:
+          - $test
+        allow:
+          - $gostd
+          - github.com/cometbft
+          - github.com/syndtr/goleveldb/leveldb
+          - github.com/stretchr/testify

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-all-with-coverage:
 
 lint:
 	@echo "--> Running linter"
-	@golangci-lint run
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 	@go mod verify
 .PHONY: lint
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ recommend depending on this library for new projects.
 
 ### Minimum Go Version
 
-Go 1.19+
+Go 1.20+
 
 ## Supported Database Backends
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.4

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -13,7 +13,10 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev \
-    make tar wget
+    make tar wget build-essential gcc-11 g++-11 
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 
 FROM build AS install
 ARG LEVELDB=1.20

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.19-bullseye AS build
+FROM golang:1.20 AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
Since we currently don't plan on using cometbft-db v0.8.0 in CometBFT v0.34.x, it seems safe to bump the minimum supported Go version for the cometbft-db v0.8.x series to Go v1.20.

Also, with regard to https://github.com/cometbft/cometbft/pull/777#issuecomment-1593743103, doing so will allow us to build a `cometbft-db-testing` image based on Go v1.20 that we can use as a base for our [CometBFT E2E test image](https://github.com/cometbft/cometbft/blob/6f7746225c378b4f4e40e80a669226385cda8bfb/test/e2e/docker/Dockerfile) that pre-packages manually built cleveldb and RocksDB support.

This way our E2E test image will be able to use whatever the current supported underlying versions of cleveldb and RocksDB have been tested with cometbft-db.

I've also updated the linting settings to use the latest version of golangci-lint locally and in CI, and have added the relevant depguard rules to get the linter to pass.