### PR TITLE
ci: Update to latest RocksDB and OS-provided leveldb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/btree v1.1.2
 	github.com/jmhodges/levigo v1.0.0
-	github.com/linxGnu/grocksdb v1.7.16
+	github.com/linxGnu/grocksdb v1.8.6
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 	go.etcd.io/bbolt v1.3.8

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/linxGnu/grocksdb v1.7.16 h1:Q2co1xrpdkr5Hx3Fp+f+f7fRGhQFQhvi/+226dtLmA8=
-github.com/linxGnu/grocksdb v1.7.16/go.mod h1:JkS7pl5qWpGpuVb3bPqTz8nC12X3YtPZT+Xq7+QfQo4=
+github.com/linxGnu/grocksdb v1.8.6 h1:O7I6SIGPrypf3f/gmrrLUBQDKfO8uOoYdWf4gLS06tc=
+github.com/linxGnu/grocksdb v1.8.6/go.mod h1:xZCIb5Muw+nhbDK4Y5UJuOrin5MceOuiXkVUR7vp4WY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -11,29 +11,14 @@ FROM golang:1.20 AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev \
-    make tar wget build-essential gcc-11 g++-11 
-
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
+RUN apt update \
+    && apt install -y \
+       libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev \
+       make tar wget build-essential \
+       libleveldb-dev libleveldb1d
 
 FROM build AS install
-ARG LEVELDB=1.20
 ARG ROCKSDB=7.10.2
-
-# Install cleveldb
-RUN \
-  wget -q https://github.com/google/leveldb/archive/v${LEVELDB}.tar.gz \
-  && tar xvf v${LEVELDB}.tar.gz \
-  && cd leveldb-${LEVELDB} \
-  && make \
-  && cp -a out-static/lib* out-shared/lib* /usr/local/lib \
-  && cd include \
-  && cp -a leveldb /usr/local/include \
-  && ldconfig \
-  && cd ../.. \
-  && rm -rf v${LEVELDB}.tar.gz leveldb-${LEVELDB}
 
 # Install Rocksdb
 RUN \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -13,16 +13,16 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 
 RUN apt update \
     && apt install -y \
-       libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev \
+       libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
        make tar wget build-essential \
        libleveldb-dev libleveldb1d
 
 FROM build AS install
-ARG ROCKSDB=7.10.2
+ARG ROCKSDB=8.8.1
 
 # Install Rocksdb
 RUN \
-  wget -q https://github.com/facebook/rocksdb/archive/v${ROCKSDB}.tar.gz \
+  wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
   && DEBUG_LEVEL=0 make -j4 shared_lib \


### PR DESCRIPTION
Based on and supersedes #95.

We need to actually update to RocksDB 8 in order to apply #95, which is what I've done in this PR.

Also, since the latest published version of leveldb is from 2021, it exists as a package in Debian Bookworm (and most other OS's), so it doesn't seem necessary to build it from source.