### PR TITLE
Update to Go v1.21

### DIFF
--- a/.changelog/unreleased/go-version/98-bump-go-v1.21.md
+++ b/.changelog/unreleased/go-version/98-bump-go-v1.21.md
@@ -1,0 +1,2 @@
+- Bump minimum Go version to v1.21 ([\#98](https://github.com/cometbft/cometbft-
+  db/pull/98))

--- a/.changelog/unreleased/go-version/98-bump-go-v1.21.md
+++ b/.changelog/unreleased/go-version/98-bump-go-v1.21.md
@@ -1,2 +1,2 @@
-- Bump minimum Go version to v1.21 ([\#98](https://github.com/cometbft/cometbft-
-  db/pull/98))
+- Bump minimum Go version to v1.21
+  ([\#98](https://github.com/cometbft/cometbft-db/pull/98))

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ recommend depending on this library for new projects.
 
 ### Minimum Go Version
 
-Go 1.20+
+Go 1.21+
 
 ## Supported Database Backends
 
@@ -46,11 +46,11 @@ Go 1.20+
   which have good performance for read-heavy workloads and range scans. Supports
   serializable ACID transactions.
 
-- **[RocksDB](https://github.com/tecbot/gorocksdb) [experimental]:** A [Go
-  wrapper](https://github.com/tecbot/gorocksdb) around
+- **[RocksDB](https://github.com/linxGnu/grocksdb) [experimental]:** A [Go
+  wrapper](https://github.com/linxGnu/grocksdb) around
   [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees
   for on-disk storage, but is optimized for fast storage media such as SSDs and
-      memory. Supports atomic transactions, but not full ACID transactions.
+  memory. Supports atomic transactions, but not full ACID transactions.
 
 - **[BadgerDB](https://github.com/dgraph-io/badger) [experimental]:** A
   key-value database written as a pure-Go alternative to e.g. LevelDB and

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.20
+go 1.21
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.4

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.20 AS build
+FROM golang:1.21 AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
In order to update the CometBFT E2E tests on `main` and for `v1.x` to make use of the latest release of cometbft-db (as per https://github.com/cometbft/cometbft/pull/777#issuecomment-1593743103), we'll need to build the Docker test image using Go v1.21.

This PR needs to be applied before #97.