### PR TITLE
Build cometbft-db-testing image for amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,5 +59,6 @@ jobs:
         with:
           context: ./tools
           file: ./tools/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
Attempts to address Docker E2E image build failure in CometBFT: https://github.com/cometbft/cometbft/actions/runs/7086189479/job/19284139356

It appears as though Docker's not finding one of the two platforms for which we're building the CometBFT E2E image. This PR syncs their build config, but I'll only know if it works once we merge this.