### PR TITLE
Release v0.9.1

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,1 +1,17 @@
 project_url = 'https://github.com/cometbft/cometbft-db'
+
+sort_releases_by = [
+    "date",
+    "version"
+]
+release_date_formats = [
+    # "*December 1, 2023*
+    "*%B %d, %Y*",
+    # "*Dec 1, 2023*
+    "*%b %d, %Y*",
+    # "2023-12-01" (ISO format)
+    "%F",
+]
+
+[change_set_sections]
+sort_entries_by = "entry-text"

--- a/.changelog/v0.9.0/dependencies/97-update-rocksdb.md
+++ b/.changelog/v0.9.0/dependencies/97-update-rocksdb.md
@@ -1,2 +1,2 @@
-- Use RocksDB 8, testing with v8.8.1
+- Use RocksDB v8, testing with v8.8.1
   ([\#97](https://github.com/cometbft/cometbft-db/pull/97))

--- a/.changelog/v0.9.1/summary.md
+++ b/.changelog/v0.9.1/summary.md
@@ -1,0 +1,5 @@
+*December 4, 2023*
+
+This release is precisely the same code-wise as v0.9.0, except that it builds
+the `cometbft/cometbft-db-testing` Docker image for both `linux/amd64` and
+`linux/arm64` platforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,10 @@ upgrade to the latest version(s) of Go ASAP.
 
 ### DEPENDENCIES
 
-- Update to the latest version of golang.org/x/net
-  ([\#40](https://github.com/cometbft/cometbft-db/pull/40))
 - Switch rocksdb binding from gorocksdb to grocksdb, bump librocksdb dependency
   to `v7.10.2` ([\#42](https://github.com/cometbft/cometbft-db/pull/42))
+- Update to the latest version of golang.org/x/net
+  ([\#40](https://github.com/cometbft/cometbft-db/pull/40))
 
 ## v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.9.1
+
+*December 4, 2023*
+
+This release is precisely the same code-wise as v0.9.0, except that it builds
+the `cometbft/cometbft-db-testing` Docker image for both `linux/amd64` and
+`linux/arm64` platforms.
+
 ## v0.9.0
 
 *December 1, 2023*


### PR DESCRIPTION
This will help trigger the cutting of the cometbft-db-testing image with support for both `linux/amd64` and `linux/arm64` platforms.

Also updates the changelog sorting/ordering to match CometBFT's.

[CHANGELOG rendered](https://github.com/cometbft/cometbft-db/blob/release/v0.9.1/CHANGELOG.md)