### PR TITLE
ci: Always check for latest Go version in govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+          check-latest: true
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:


### PR DESCRIPTION
Noticed a few dependency update workflows are failing and it seems to be due to GitHub Actions caching a slightly outdated version of Go.

We do this in CometBFT to ensure we always have the absolute latest version of Go: https://github.com/cometbft/cometbft/blob/148eebdab2fbf44cec4f1de3c07ce53ef02d4509/.github/workflows/govulncheck.yml#L22