### PR TITLE
fix: add pebble to the ci test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test-pebble:
 
 test-all:
 	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags cleveldb,boltdb,rocksdb,grocksdb_clean_link,badgerdb -v
+	@go test $(PACKAGES) -tags cleveldb,boltdb,rocksdb,grocksdb_clean_link,badgerdb,pebbledb -v
 .PHONY: test-all
 
 test-all-with-coverage:


### PR DESCRIPTION
This PR 

* adds pebble to CI test runs for cometbft-db