### PR TITLE
fix(pebbledb): Initialize DB in batchDB constructor

### DIFF
--- a/pebble.go
+++ b/pebble.go
@@ -207,6 +207,11 @@ var _ Batch = (*pebbleDBBatch)(nil)
 
 func newPebbleDBBatch(db *PebbleDB) *pebbleDBBatch {
 	return &pebbleDBBatch{
+		// For regular batch operations batch.db is going to be set to db
+		// and it is not needed to initialize the DB here.
+		// This is set to enable general DB operations like compaction
+		// (e.x. a call do pebbleDBBatch.db.Compact() would throw a nil pointer exception)
+		db:    db,
 		batch: db.db.NewBatch(),
 	}
 }


### PR DESCRIPTION
As described in the comment, there is no specific need to initialize the DB for the batch version of pebble DB. But if we want to add functions like compaction, we need this to be initialized to something to avoid null pointer exceptions. 