### PR TITLE
feat!: Iterator `Key()` and `Value()` no longer return a copy

### DIFF
--- a/.changelog/v0.13.0/features/168-iter-key.md
+++ b/.changelog/v0.13.0/features/168-iter-key.md
@@ -1,0 +1,2 @@
+- Iterator Key and Value APIs now return an object that must be copied before
+  use ([\#168](https://github.com/cometbft/cometbft-db/pull/168))

--- a/.changelog/v0.13.0/summary.md
+++ b/.changelog/v0.13.0/summary.md
@@ -1,0 +1,7 @@
+<!--
+    Add a summary for the release here.
+
+    If you don't change this message, or if this file is empty, the release
+    will not be created. -->
+This release changes the contract of the Iterator Key() and Value() APIs.
+Namely, the caller is now responsible for creating a copy of their returned value if they want to modify it.

--- a/backend_test.go
+++ b/backend_test.go
@@ -451,7 +451,10 @@ func assertKeyValues(t *testing.T, db DB, expect map[string][]byte) {
 	actual := make(map[string][]byte)
 	for ; iter.Valid(); iter.Next() {
 		require.NoError(t, iter.Error())
-		actual[string(iter.Key())] = iter.Value()
+
+		value := make([]byte, len(iter.Value()))
+		copy(value, iter.Value())
+		actual[string(iter.Key())] = value
 	}
 
 	assert.Equal(t, expect, actual)

--- a/backend_test.go
+++ b/backend_test.go
@@ -348,7 +348,8 @@ func verifyIterator(t *testing.T, itr Iterator, expected []int64, msg string) {
 
 	var list []int64
 	for itr.Valid() {
-		key := itr.Key()
+		key := make([]byte, len(itr.Key()))
+		copy(key, itr.Key())
 		list = append(list, bytes2Int64(key))
 		itr.Next()
 	}

--- a/badger_db.go
+++ b/badger_db.go
@@ -281,7 +281,7 @@ func (i *badgerDBIterator) Valid() bool {
 
 // Key implements Iterator.
 // The caller should not modify the contents of the returned slice.
-// To work with the slice, make a copy and modify the copy instead.
+// Instead, the caller should make a copy and work on the copy.
 func (i *badgerDBIterator) Key() []byte {
 	if !i.Valid() {
 		panic("iterator is invalid")
@@ -289,10 +289,14 @@ func (i *badgerDBIterator) Key() []byte {
 	return i.iter.Item().Key()
 }
 
+// Value implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// Instead, the caller should make a copy and work on the copy.
 func (i *badgerDBIterator) Value() []byte {
 	if !i.Valid() {
 		panic("iterator is invalid")
 	}
+
 	val, err := i.iter.Item().ValueCopy(nil)
 	if err != nil {
 		i.lastErr = err

--- a/badger_db.go
+++ b/badger_db.go
@@ -290,6 +290,7 @@ func (i *badgerDBIterator) Key() []byte {
 }
 
 // Value implements Iterator.
+// The returned slice is a copy of the original data, therefore it is safe to modify.
 func (i *badgerDBIterator) Value() []byte {
 	if !i.Valid() {
 		panic("iterator is invalid")

--- a/badger_db.go
+++ b/badger_db.go
@@ -290,8 +290,6 @@ func (i *badgerDBIterator) Key() []byte {
 }
 
 // Value implements Iterator.
-// The caller should not modify the contents of the returned slice.
-// Instead, the caller should make a copy and work on the copy.
 func (i *badgerDBIterator) Value() []byte {
 	if !i.Valid() {
 		panic("iterator is invalid")

--- a/badger_db.go
+++ b/badger_db.go
@@ -279,13 +279,14 @@ func (i *badgerDBIterator) Valid() bool {
 	return true
 }
 
+// Key implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// To work with the slice, make a copy and modify the copy instead.
 func (i *badgerDBIterator) Key() []byte {
 	if !i.Valid() {
 		panic("iterator is invalid")
 	}
-	// Note that we don't use KeyCopy, so this is only valid until the next
-	// call to Next.
-	return i.iter.Item().KeyCopy(nil)
+	return i.iter.Item().Key()
 }
 
 func (i *badgerDBIterator) Value() []byte {

--- a/common_test.go
+++ b/common_test.go
@@ -72,7 +72,9 @@ func checkKeyPanics(t *testing.T, itr Iterator) {
 
 func checkValuePanics(t *testing.T, itr Iterator) {
 	t.Helper()
-	assert.Panics(t, func() { itr.Value() })
+
+	msg := "checkValuePanics expected panic but didn't"
+	assert.Panics(t, func() { itr.Value() }, msg)
 }
 
 func newTempDB(t *testing.T, backend BackendType) (db DB, dbDir string) {

--- a/goleveldb_iterator.go
+++ b/goleveldb_iterator.go
@@ -94,18 +94,18 @@ func (itr *goLevelDBIterator) Valid() bool {
 
 // Key implements Iterator.
 // The caller should not modify the contents of the returned slice.
-// To work with the slice, make a copy and modify the copy instead.
+// Instead, the caller should make a copy and work on the copy.
 func (itr *goLevelDBIterator) Key() []byte {
 	itr.assertIsValid()
 	return itr.source.Key()
 }
 
 // Value implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// Instead, the caller should make a copy and work on the copy.
 func (itr *goLevelDBIterator) Value() []byte {
-	// Value returns a copy of the current value.
-	// See https://github.com/syndtr/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
 	itr.assertIsValid()
-	return cp(itr.source.Value())
+	return itr.source.Value()
 }
 
 // Next implements Iterator.

--- a/goleveldb_iterator.go
+++ b/goleveldb_iterator.go
@@ -93,11 +93,11 @@ func (itr *goLevelDBIterator) Valid() bool {
 }
 
 // Key implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// To work with the slice, make a copy and modify the copy instead.
 func (itr *goLevelDBIterator) Key() []byte {
-	// Key returns a copy of the current key.
-	// See https://github.com/syndtr/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
 	itr.assertIsValid()
-	return cp(itr.source.Key())
+	return itr.source.Key()
 }
 
 // Value implements Iterator.

--- a/pebble.go
+++ b/pebble.go
@@ -397,18 +397,18 @@ func (itr *pebbleDBIterator) Valid() bool {
 
 // Key implements Iterator.
 // The caller should not modify the contents of the returned slice.
-// To work with the slice, make a copy and modify the copy instead.
+// Instead, the caller should make a copy and work on the copy.
 func (itr *pebbleDBIterator) Key() []byte {
 	itr.assertIsValid()
 	return itr.source.Key()
 }
 
 // Value implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// Instead, the caller should make a copy and work on the copy.
 func (itr *pebbleDBIterator) Value() []byte {
-	// Value returns a copy of the current value.
-	// See https://github.com/cockroachdb/pebble/blob/v1.0.0/iterator.go#L2116
 	itr.assertIsValid()
-	return cp(itr.source.Value())
+	return itr.source.Value()
 }
 
 // Next implements Iterator.

--- a/pebble.go
+++ b/pebble.go
@@ -396,11 +396,11 @@ func (itr *pebbleDBIterator) Valid() bool {
 }
 
 // Key implements Iterator.
+// The caller should not modify the contents of the returned slice.
+// To work with the slice, make a copy and modify the copy instead.
 func (itr *pebbleDBIterator) Key() []byte {
-	// Key returns a copy of the current key.
-	// See https://github.com/cockroachdb/pebble/blob/v1.0.0/iterator.go#L2106
 	itr.assertIsValid()
-	return cp(itr.source.Key())
+	return itr.source.Key()
 }
 
 // Value implements Iterator.

--- a/rocksdb_iterator.go
+++ b/rocksdb_iterator.go
@@ -94,12 +94,14 @@ func (itr *rocksDBIterator) Valid() bool {
 }
 
 // Key implements Iterator.
+// The returned slice is a copy of the original data, therefore it is safe to modify.
 func (itr *rocksDBIterator) Key() []byte {
 	itr.assertIsValid()
 	return moveSliceToBytes(itr.source.Key())
 }
 
 // Value implements Iterator.
+// The returned slice is a copy of the original data, therefore it is safe to modify.
 func (itr *rocksDBIterator) Value() []byte {
 	itr.assertIsValid()
 	return moveSliceToBytes(itr.source.Value())

--- a/types.go
+++ b/types.go
@@ -139,12 +139,14 @@ type Iterator interface {
 	// Key returns the key of the current key/value pair, or nil if done.
 	// The caller should not modify the contents of the returned slice, and
 	// its contents may change on the next call to any 'seeks method'.
+	// Instead, the caller should make a copy and work on the copy.
 	Key() (key []byte)
 
 	// Value returns the value at the current position. Panics if the iterator is invalid.
 	// Value returns the value of the current key/value pair, or nil if done.
 	// The caller should not modify the contents of the returned slice, and
 	// its contents may change on the next call to any 'seeks method'.
+	// Instead, the caller should make a copy and work on the copy.
 	Value() (value []byte)
 
 	// Error returns the last error encountered by the iterator, if any.

--- a/types.go
+++ b/types.go
@@ -136,11 +136,15 @@ type Iterator interface {
 	Next()
 
 	// Key returns the key at the current position. Panics if the iterator is invalid.
-	// CONTRACT: key readonly []byte
+	// Key returns the key of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
 	Key() (key []byte)
 
 	// Value returns the value at the current position. Panics if the iterator is invalid.
-	// CONTRACT: value readonly []byte
+	// Value returns the value of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
 	Value() (value []byte)
 
 	// Error returns the last error encountered by the iterator, if any.


### PR DESCRIPTION
### Context
Closes #156.

### Changes

The:
- `Iterator.Key()` API implementations of levelDB, badgerDB, and pebbleDB no longer return a copy of the key.
- `Iterator.Value()` API implementations of levelDB and pebbleDB no longer return a copy of the value.

Rather, as the updated docs reflect, the caller is responsible for creating a copy of the slice if they want to modify it.

See my further comments about [rocksdb](https://github.com/cometbft/cometbft-db/pull/168#issuecomment-2222932698) and [badgerdb](https://github.com/cometbft/cometbft-db/pull/168#issuecomment-2223080924) below.

