### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v0.13.0
+
+This release:
+- changes the contract of the Iterator Key() and Value() APIs: the caller
+is now responsible for creating a copy of their returned value if they want to modify it.
+- bumps the Go version to 1.22.5 (from 1.22). Go 1.22.5 does not introduce new language
+features, therefore code using older version will still compile. However, we recommend to
+upgrade to the latest version(s) of Go as soon as possible.
+
+
+### FEATURES
+
+- Iterator Key and Value APIs now return an object that must be copied before
+  use ([\#168](https://github.com/cometbft/cometbft-db/pull/168))
+
 ## v0.12.0
 
 *Apr 10, 2024*
@@ -124,4 +139,3 @@ effectively as of v0.6.6.
 For changes prior to the creation of this fork, please refer to the upstream
 [CHANGELOG.md](https://github.com/tendermint/tm-db/blob/774cdfe7e6b0a249b1144998d81a4de7b8037941/CHANGELOG.md)
 for v0.6.6 and earlier.
-


### PR DESCRIPTION
This PR creates release `v0.13.0` of cometbft-db.

This release:
- changes the contract of the `Iterator` `Key()` and `Value()` APIs: the caller
is now responsible for creating a copy of their returned value if they want to modify it.
- bumps the Go version to `1.22.5` (from `1.22`).