### PR TITLE
Update v0.13.0 Changelog

### DIFF
--- a/.changelog/v0.13.0/breaking-changes/155-remove-bolt-cleveldb.md
+++ b/.changelog/v0.13.0/breaking-changes/155-remove-bolt-cleveldb.md
@@ -1,0 +1,1 @@
+- removed deprecated boltdb and cleveldb ([\#155](https://github.com/cometbft/cometbft-db/pull/155))

--- a/.changelog/v0.13.0/summary.md
+++ b/.changelog/v0.13.0/summary.md
@@ -1,8 +1,9 @@
 <!--
     Add a summary for the release here.
-
     If you don't change this message, or if this file is empty, the release
     will not be created. -->
+*Aug 2, 2024*
+
 This release:
 - changes the contract of the Iterator Key() and Value() APIs. Namely, the caller is now responsible for creating a copy of their returned value if they want to modify it.
 - removes support for boltDB and clevelDB, which were marked as deprecated in release v0.12.0.

--- a/.changelog/v0.13.0/summary.md
+++ b/.changelog/v0.13.0/summary.md
@@ -3,5 +3,6 @@
 
     If you don't change this message, or if this file is empty, the release
     will not be created. -->
-This release changes the contract of the Iterator Key() and Value() APIs.
-Namely, the caller is now responsible for creating a copy of their returned value if they want to modify it.
+This release:
+- changes the contract of the Iterator Key() and Value() APIs. Namely, the caller is now responsible for creating a copy of their returned value if they want to modify it.
+- removes support for boltDB and clevelDB, which were marked as deprecated in release v0.12.0.

--- a/.changelog/v0.13.0/summary.md
+++ b/.changelog/v0.13.0/summary.md
@@ -1,7 +1,3 @@
-<!--
-    Add a summary for the release here.
-    If you don't change this message, or if this file is empty, the release
-    will not be created. -->
 *Aug 2, 2024*
 
 This release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ is now responsible for creating a copy of their returned value if they want to m
 - bumps the Go version to 1.22.5 (from 1.22). Go 1.22.5 does not introduce new language
 features, therefore code using older version will still compile. However, we recommend to
 upgrade to the latest version(s) of Go as soon as possible.
+- removes support for boltDB and clevelDB.
 
+
+### BREAKING CHANGES
+
+- removed deprecated boltdb and cleveldb ([\#155](https://github.com/cometbft/cometbft-db/pull/155))
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.13.0
 
+*Aug 2, 2024*
+
 This release:
 - changes the contract of the Iterator Key() and Value() APIs: the caller
 is now responsible for creating a copy of their returned value if they want to modify it.


### PR DESCRIPTION
Closes #175.

### Context
The changelog of release v0.13.0 does not mention that we removed support for boltDB and clevelDB in this release.

### Changes
This PR adds this information to the changelog.