### PR TITLE
Retract `v0.9.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,5 +33,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// Breaking changes were released with the wrong tag (use v0.6.6 or later).
-retract v0.6.5
+retract (
+	// Breaking changes were released with the wrong tag (use v0.6.6 or later).
+	v0.6.5
+	// This version was mistakenly created.
+	v0.9.2
+)


### PR DESCRIPTION
### Context
We accidentally created the tag `v0.9.2` at a wrong point in the commit history.
Therefore, we have to retract this version to prevent its use.

### This Change
This PR retracts `v0.9.2` from the `go.mod` of the project.