### PR TITLE
build(deps): Bump minimum Go version to v1.23

### DIFF
--- a/.changelog/unreleased/breaking-changes/4039-go-2024-3107.md
+++ b/.changelog/unreleased/breaking-changes/4039-go-2024-3107.md
@@ -1,0 +1,2 @@
+- `[go/runtime]` Bump minimum Go version to v1.23
+  ([\#4039](https://github.com/cometbft/cometbft/issues/4039))

--- a/.github/workflows/go-version.env
+++ b/.github/workflows/go-version.env
@@ -1,2 +1,2 @@
 # .github/go-version.env
-GO_VERSION=1.22.5
+GO_VERSION=1.23.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/cockroachdb/pebble v1.1.2

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.22.5 AS build
+FROM golang:1.23.1 AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
Refs https://github.com/cometbft/cometbft/issues/4039