### PR TITLE
chore: Update go version to `1.22.7` on `v0.14.x` release branch

### DIFF
--- a/.changelog/unreleased/dependencies/197-bump-go.md
+++ b/.changelog/unreleased/dependencies/197-bump-go.md
@@ -1,0 +1,2 @@
+- `[go/runtime]` Bump minimum Go version to 1.22.7
+  ([\#197](https://github.com/cometbft/cometbft-db/issues/197))

--- a/.github/workflows/go-version.env
+++ b/.github/workflows/go-version.env
@@ -1,2 +1,2 @@
 # .github/go-version.env
-GO_VERSION=1.22.5
+GO_VERSION=1.22.7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,13 +5,12 @@ run:
 linters:
   disable-all: true
   enable:
-    - exportloopref
+    - copyloopvar
     - errcheck
     - gci
     - goconst
     - gocritic
     - gofumpt
-    - gosec
     - gosimple
     - govet
     - ineffassign

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/cockroachdb/pebble v1.1.1

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.22.5 AS build
+FROM golang:1.22.7 AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
Fixes: #197 