### PR TITLE
fix: add missing changelog entry for RocksDB bump

### DIFF
--- a/.changelog/v0.15.0/dependencies/189-bump-gorocksdb-version.md
+++ b/.changelog/v0.15.0/dependencies/189-bump-gorocksdb-version.md
@@ -1,0 +1,2 @@
+- Use RocksDB 9, testing with v9.3.1
+  ([\#189](https://github.com/cometbft/cometbft-db/pull/189))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ This release bumps the Go version to 1.23.
 - `[go/runtime]` Bump minimum Go version to v1.23
   ([\#4039](https://github.com/cometbft/cometbft/issues/4039))
 
+### DEPENDENCIES
+
+- Use RocksDB 9, testing with v9.3.1
+  ([\#189](https://github.com/cometbft/cometbft-db/pull/189))
+
 ## v0.14.0
 
 *Aug 9, 2024*


### PR DESCRIPTION
A changelog entry was missed about the RocksDB version bump

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
