### PR TITLE
ci: allow changing Git ref name in docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,11 @@
 name: Docker testing image
 on:
   workflow_dispatch:  # allow running workflow manually
+    inputs:
+      refName:
+        description: 'Git ref name'
+        required: true
+        default: 'main'
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"               # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -43,4 +48,4 @@ jobs:
           push: true
           tags: |
             cometbft/cometbft-db-testing:latest
-            cometbft/cometbft-db-testing:${{ github.ref_name }}
+            cometbft/cometbft-db-testing:${{ github.event.inputs.refName }}


### PR DESCRIPTION
so that we can publish `v1.0.2` image by manually triggering the job with `refName = v1.0.2`