### PR TITLE
fix(tools): bring back arm64 target

### DIFF
--- a/.changelog/unreleased/bug-fixes/234-fix-arm64-build.md
+++ b/.changelog/unreleased/bug-fixes/234-fix-arm64-build.md
@@ -1,0 +1,2 @@
+- `[docker]` Bring back `arm64` build target
+  ([\#234](https://github.com/cometbft/cometbft-db/issues/234))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,20 @@ jobs:
         with:
           driver: docker
 
-      - name: Build Docker image
+      - name: Build Docker image (arm64) to ensure it works
+        uses: docker/build-push-action@v6
+        with:
+          context: ./tools
+          file: ./tools/Dockerfile
+          platforms: linux/arm64
+
+      - name: Build Docker image (amd64) to be used in the next step
         uses: docker/build-push-action@v6
         with:
           context: ./tools
           file: ./tools/Dockerfile
           tags: "cometbft/cometbft-db-testing:latest"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           load: true
 
       - name: test & coverage report creation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           driver: docker
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build Docker image (arm64) to ensure it works
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,11 @@ jobs:
         with:
           driver: docker
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Build Docker image (arm64) to ensure it works
         uses: docker/build-push-action@v6
         with:
           context: ./tools
-          file: ./tools/Dockerfile
+          file: ./tools/Dockerfile.arm64
           platforms: linux/arm64
 
       - name: Build Docker image (amd64) to be used in the next step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check if Docker image exists
         id: check
         run: |
-          if docker manifest inspect cometbft/cometbft-db-testing:v1.0.2 &>/dev/null; then
+          if docker manifest inspect cometbft/cometbft-db-testing:v1.0.3 &>/dev/null; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -30,7 +30,7 @@ jobs:
     needs: check-container
     if: needs.check-container.outputs.exists == 'true'
     runs-on: ubuntu-latest
-    container: cometbft/cometbft-db-testing:v1.0.2
+    container: cometbft/cometbft-db-testing:v1.0.3
     steps:
       - uses: actions/checkout@v4
 
@@ -67,6 +67,7 @@ jobs:
           context: ./tools
           file: ./tools/Dockerfile
           tags: "cometbft/cometbft-db-testing:latest"
+          platforms: linux/amd64,linux/arm64
           load: true
 
       - name: test & coverage report creation

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,12 +39,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
+      - name: Publish to Docker Hub (amd64)
         uses: docker/build-push-action@v6
         with:
           context: ./tools
           file: ./tools/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          push: true
+          tags: |
+            cometbft/cometbft-db-testing:latest
+            cometbft/cometbft-db-testing:${{ github.event.inputs.refName }}
+
+      - name: Publish to Docker Hub (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./tools
+          file: ./tools/Dockerfile.arm64
+          platforms: linux/arm64
           push: true
           tags: |
             cometbft/cometbft-db-testing:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           context: ./tools
           file: ./tools/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             cometbft/cometbft-db-testing:latest

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -10,7 +10,7 @@
 # PLEASE BUMP THE VERSION OF THE IMAGE IN `.github/workflows/ci.yml` WHEN YOU
 # MODIFY THIS FILE.
 
-FROM golang:1.23.5 AS build
+FROM golang:1.23.5
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
@@ -27,8 +27,8 @@ RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 make -j$(nproc) shared_lib \
-  && make install \
+  && DEBUG_LEVEL=0 make shared_lib \
+  && make install-shared \
   && ldconfig \
   && cd .. \
   && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,7 +16,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 
 RUN apt update \
     && apt install -y \
-       libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
+       libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
        make tar wget build-essential g++ cmake \
        libleveldb-dev libleveldb1d
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,18 +17,17 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 RUN apt update \
     && apt install -y \
        libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
-       make tar wget build-essential \
+       make tar wget build-essential g++ cmake \
        libleveldb-dev libleveldb1d
 
-FROM build AS install
 ARG ROCKSDB=9.8.4
 
-# Install Rocksdb
+# Install RocksDB
 RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 make -j$(nproc) static_lib \
+  && DEBUG_LEVEL=0 PORTABLE=1 make -j$(nproc) static_lib \
   && make install \
   && cd .. \
   && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -27,8 +27,7 @@ RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 make shared_lib \
+  && DEBUG_LEVEL=0 make -j4 shared_lib \
   && make install-shared \
-  && ldconfig \
   && cd .. \
   && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -27,7 +27,8 @@ RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 PORTABLE=1 make -j$(nproc) static_lib \
+  && DEBUG_LEVEL=0 make -j$(nproc) shared_lib \
   && make install \
+  && ldconfig \
   && cd .. \
   && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,7 +16,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 
 RUN apt update \
     && apt install -y \
-       libbz2-dev libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
+       libgflags-dev libsnappy-dev libzstd-dev zlib1g-dev liblz4-dev \
        make tar wget build-essential \
        libleveldb-dev libleveldb1d
 
@@ -28,8 +28,7 @@ RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 make -j4 shared_lib \
-  && make install-shared \
-  && ldconfig \
+  && DEBUG_LEVEL=0 make -j$(nproc) static_lib \
+  && make install \
   && cd .. \
   && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}

--- a/tools/Dockerfile.arm64
+++ b/tools/Dockerfile.arm64
@@ -1,0 +1,18 @@
+# This file defines the container image used to build and test tm-db in CI.
+# The CI workflows use the latest tag of cometbft/cometbft-db-testing built
+# from these settings.
+#
+# The jobs defined in the Build & Push workflow will build and update the image
+# when changes to this file are merged.  If you have other changes that require
+# updates here, merge the changes here first and let the image get updated (or
+# push a new version manually) before PRs that depend on them.
+
+# PLEASE BUMP THE VERSION OF THE IMAGE IN `.github/workflows/ci.yml` WHEN YOU
+# MODIFY THIS FILE.
+
+FROM golang:1.23.5
+
+RUN apt update \
+    && apt install -y \
+       librocksdb-dev \
+       libleveldb-dev libleveldb1d

--- a/tools/Dockerfile.arm64
+++ b/tools/Dockerfile.arm64
@@ -12,7 +12,4 @@
 
 FROM golang:1.23.5
 
-RUN apt update \
-    && apt install -y \
-       librocksdb-dev \
-       libleveldb-dev libleveldb1d
+RUN apt update && apt install -y libleveldb-dev libleveldb1d


### PR DESCRIPTION
Contributes to #234 

Removes `rocksdb` from docker due to segfault.

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
