### PR TITLE
build(deps): bump Go version

### DIFF
--- a/.changelog/unreleased/dependencies/236-bump-go-version.md
+++ b/.changelog/unreleased/dependencies/236-bump-go-version.md
@@ -1,0 +1,2 @@
+- `[deps]` Bump Go version to 1.23.6
+  ([\#236](https://github.com/cometbft/cometbft-db/pull/236))

--- a/.github/workflows/go-version.env
+++ b/.github/workflows/go-version.env
@@ -1,2 +1,2 @@
 # .github/go-version.env
-GO_VERSION=1.23.5
+GO_VERSION=1.23.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/cockroachdb/pebble v1.1.4

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -10,7 +10,7 @@
 # PLEASE BUMP THE VERSION OF THE IMAGE IN `.github/workflows/ci.yml` WHEN YOU
 # MODIFY THIS FILE.
 
-FROM golang:1.23.5
+FROM golang:1.23.6
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/tools/Dockerfile.arm64
+++ b/tools/Dockerfile.arm64
@@ -10,6 +10,6 @@
 # PLEASE BUMP THE VERSION OF THE IMAGE IN `.github/workflows/ci.yml` WHEN YOU
 # MODIFY THIS FILE.
 
-FROM golang:1.23.5
+FROM golang:1.23.6
 
 RUN apt update && apt install -y libleveldb-dev libleveldb1d


### PR DESCRIPTION
includes security fixes to the crypto/elliptic package, as well as bug fixes to the compiler and the go command.