### PR TITLE
chore: relax Go version constraint to 1.23

### DIFF
--- a/.github/workflows/go-version.env
+++ b/.github/workflows/go-version.env
@@ -1,2 +1,0 @@
-# .github/go-version.env
-GO_VERSION=1.23.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.23.6
+go 1.23
 
 require (
 	github.com/cockroachdb/pebble v1.1.4

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.6
+FROM golang:1.23
 
 RUN apt update \
     && apt install -y \


### PR DESCRIPTION
This PR relaxes the Go restraint to 1.23. In modules that include it, it will require 1.23, but will be flexible to the patch version that module is on.

I removed the Github Action env variable since it doesn't look like we use it anymore. Perhaps in the recent Github Action refactors we removed it's usage. (If workflows start failing I will need to restore this, but I can't find any references to it in the code).

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
