### PR TITLE
build(deps): bump Go version to 1.22.12

### DIFF
--- a/.changelog/unreleased/dependencies/260-bump-go.md
+++ b/.changelog/unreleased/dependencies/260-bump-go.md
@@ -1,0 +1,2 @@
+- `[go/runtime]` Bump minimum Go version to 1.22.12
+  ([\#260](https://github.com/cometbft/cometbft-db/issue/260))

--- a/.github/workflows/go-version.env
+++ b/.github/workflows/go-version.env
@@ -1,2 +1,2 @@
 # .github/go-version.env
-GO_VERSION=1.22.11
+GO_VERSION=1.22.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft-db
 
-go 1.22.11
+go 1.22.12
 
 require (
 	github.com/cockroachdb/pebble v1.1.1

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.11
+FROM golang:1.22.12
 
 RUN apt update \
     && apt install -y \


### PR DESCRIPTION
Closes #260 

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
