### PR TITLE
fix(pebble.go): implement flush threshold for Pebble batch operations

### DIFF
--- a/pebble.go
+++ b/pebble.go
@@ -21,6 +21,7 @@ type PebbleDB struct {
 }
 
 var _ DB = (*PebbleDB)(nil)
+const flushThreshold = 3_500_000_000 // ~3.5 GB
 
 func NewPebbleDB(name string, dir string) (*PebbleDB, error) {
 	opts := &pebble.Options{}
@@ -250,6 +251,14 @@ func (b *pebbleDBBatch) Set(key, value []byte) error {
 		return errBatchClosed
 	}
 
+	// Prevent Pebble batch from exceeding 4 GB hard limit
+	if b.batch.Len() > flushThreshold {
+		if err := b.batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		b.batch.Reset()
+	}
+
 	return b.batch.Set(key, value, nil)
 }
 
@@ -260,6 +269,14 @@ func (b *pebbleDBBatch) Delete(key []byte) error {
 	}
 	if b.batch == nil {
 		return errBatchClosed
+	}
+
+	// Prevent Pebble batch from exceeding 4 GB hard limit
+	if b.batch.Len() > flushThreshold {
+		if err := b.batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		b.batch.Reset()
 	}
 
 	return b.batch.Delete(key, nil)


### PR DESCRIPTION
Added a flush threshold to prevent Pebble batch from exceeding 4 GB limit during write operations.
Cometbft-db just executes set and delete on the batches without checking for the size. Pebble has a hard-coded limit of batch sizes to 4GB
<img width="784" height="222" alt="grafik" src="https://github.com/user-attachments/assets/d8a8c8f1-cde8-442e-9a2f-7960929c7e38" />

This can lead to node panic in case there is massive data compaction/migrations.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
