### PR TITLE
fix: rocksdb DeleteSync

### DIFF
--- a/rocksdb.go
+++ b/rocksdb.go
@@ -137,7 +137,7 @@ func (db *RocksDB) DeleteSync(key []byte) error {
 	}
 	err := db.db.Delete(db.woSync, key)
 	if err != nil {
-		return nil
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes error handling in `rocksdb.go`**
> 
> - `DeleteSync` now returns the underlying error from `db.db.Delete(db.woSync, key)` rather than `nil`, ensuring delete failures are surfaced to callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97d6bec5598e3a937bed4492253167f7ce1618bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->