### PR TITLE
chore: use pointer receivers for PebbleDB methods

### DIFF
--- a/pebble.go
+++ b/pebble.go
@@ -114,7 +114,7 @@ func (db *PebbleDB) Delete(key []byte) error {
 }
 
 // DeleteSync implements DB.
-func (db PebbleDB) DeleteSync(key []byte) error {
+func (db *PebbleDB) DeleteSync(key []byte) error {
 	if len(key) == 0 {
 		return errKeyEmpty
 	}
@@ -153,7 +153,7 @@ func (db *PebbleDB) Compact(start, end []byte) (err error) {
 }
 
 // Close implements DB.
-func (db PebbleDB) Close() error {
+func (db *PebbleDB) Close() error {
 	db.db.Close()
 	return nil
 }
@@ -400,7 +400,7 @@ func (itr *pebbleDBIterator) Value() []byte {
 }
 
 // Next implements Iterator.
-func (itr pebbleDBIterator) Next() {
+func (itr *pebbleDBIterator) Next() {
 	itr.assertIsValid()
 	if itr.isReverse {
 		itr.source.Prev()

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 make -j4 shared_lib \
+  && DEBUG_LEVEL=0 CXXFLAGS="-Wno-maybe-uninitialized" make -j4 shared_lib \
   && make install-shared \
   && ldconfig \
   && cd .. \


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts select `PebbleDB` and iterator methods to use pointer receivers to avoid value copies and ensure stateful behavior.
> 
> - Change `DeleteSync`, `Close`, and iterator `Next` to pointer receivers in `pebble.go`
> - No logic changes to method bodies; interfaces continue to be implemented via `*PebbleDB`
> - Update `tools/Dockerfile` to add `CXXFLAGS="-Wno-maybe-uninitialized"` when building RocksDB to suppress compiler warnings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf2e2826f8b01cd8bd9fa712f8cd0b7f2c18482. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->