### PR TITLE
fix: prevent PrefixDB from closing underlying DB and copying prefix

### DIFF
--- a/prefixdb.go
+++ b/prefixdb.go
@@ -160,7 +160,7 @@ func (pdb *PrefixDB) NewBatch() Batch {
 }
 
 // Close implements DB.
-func (pdb *PrefixDB) Close() error {
+func (_ *PrefixDB) Close() error {
 	// PrefixDB doesn't own the underlying database, so Close is a no-op.
 	// The underlying DB should be closed by its owner, not by prefix wrappers.
 	return nil

--- a/prefixdb.go
+++ b/prefixdb.go
@@ -17,7 +17,7 @@ var _ DB = (*PrefixDB)(nil)
 // NewPrefixDB lets you namespace multiple DBs within a single DB.
 func NewPrefixDB(db DB, prefix []byte) *PrefixDB {
 	return &PrefixDB{
-		prefix: prefix,
+		prefix: cp(prefix),
 		db:     db,
 	}
 }
@@ -161,10 +161,9 @@ func (pdb *PrefixDB) NewBatch() Batch {
 
 // Close implements DB.
 func (pdb *PrefixDB) Close() error {
-	pdb.mtx.Lock()
-	defer pdb.mtx.Unlock()
-
-	return pdb.db.Close()
+	// PrefixDB doesn't own the underlying database, so Close is a no-op.
+	// The underlying DB should be closed by its owner, not by prefix wrappers.
+	return nil
 }
 
 // Print implements DB.

--- a/prefixdb.go
+++ b/prefixdb.go
@@ -160,7 +160,7 @@ func (pdb *PrefixDB) NewBatch() Batch {
 }
 
 // Close implements DB.
-func (_ *PrefixDB) Close() error {
+func (*PrefixDB) Close() error {
 	// PrefixDB doesn't own the underlying database, so Close is a no-op.
 	// The underlying DB should be closed by its owner, not by prefix wrappers.
 	return nil


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

-->

---

#### PR checklist


- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **PrefixDB behavior:** `NewPrefixDB` now defensively copies `prefix` (`cp(prefix)`), and `Close()` is a no-op to avoid closing the underlying `DB`.
> - **Build tooling:** Updates `tools/Dockerfile` to use RocksDB `9.11.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ee7c5240377d3948aa313b4b9d27e57ff3940c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->