### PR TITLE
test: add unit tests for rocksdb and pebbledb

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -163,6 +163,10 @@ func testBackendGetSetDelete(t *testing.T, backend BackendType) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{0x0a}, value)
 
+	value, err = db.Get([]byte("cmp/c"))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x0c}, value)
+
 	if strings.Contains(string(backend), "pebbledb") {
 		// When running the test the folder can't be cleaned up and there
 		// is a panic on removing the tmp testing directories.

--- a/backend_test.go
+++ b/backend_test.go
@@ -150,6 +150,19 @@ func testBackendGetSetDelete(t *testing.T, backend BackendType) {
 	err = db.Compact(nil, nil)
 	require.NoError(t, err)
 
+	// Compaction over a specific range should succeed and keep data accessible.
+	err = db.Set([]byte("cmp/a"), []byte{0x0a})
+	require.NoError(t, err)
+	err = db.Set([]byte("cmp/c"), []byte{0x0c})
+	require.NoError(t, err)
+
+	err = db.Compact([]byte("cmp/a"), []byte("cmp/d"))
+	require.NoError(t, err)
+
+	value, err = db.Get([]byte("cmp/a"))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x0a}, value)
+
 	if strings.Contains(string(backend), "pebbledb") {
 		// When running the test the folder can't be cleaned up and there
 		// is a panic on removing the tmp testing directories.

--- a/pebble_test.go
+++ b/pebble_test.go
@@ -37,4 +37,146 @@ func BenchmarkPebbleDBRandomReadsWrites(b *testing.B) {
 	benchmarkRandomReadsWrites(b, db)
 }
 
-// TODO: Add tests for pebble
+func TestPebbleDBNewPebbleDB(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	defer cleanupDBDir("", name)
+
+	// Test we can't open the db twice for writing
+	wr1, err := NewPebbleDB(name, "")
+	require.NoError(t, err)
+	_, err = NewPebbleDB(name, "")
+	require.Error(t, err, "should not be able to open db twice")
+	err = wr1.Close()
+	require.NoError(t, err)
+}
+
+func TestPebbleDBCompact(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Write some data
+	for i := 0; i < 100; i++ {
+		key := []byte(fmt.Sprintf("key%03d", i))
+		value := []byte(fmt.Sprintf("value%03d", i))
+		err = db.Set(key, value)
+		require.NoError(t, err)
+	}
+
+	// Test compaction with nil start and end
+	err = db.Compact(nil, nil)
+	require.NoError(t, err)
+
+	// Test compaction with specific range
+	err = db.Compact([]byte("key000"), []byte("key050"))
+	require.NoError(t, err)
+
+	// Verify data is still accessible after compaction
+	value, err := db.Get([]byte("key025"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value025"), value)
+}
+
+func TestPebbleDBDeleteSync(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Set a key
+	key := []byte("testkey")
+	value := []byte("testvalue")
+	err = db.SetSync(key, value)
+	require.NoError(t, err)
+
+	// Verify it exists
+	got, err := db.Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, value, got)
+
+	// Delete it synchronously
+	err = db.DeleteSync(key)
+	require.NoError(t, err)
+
+	// Verify it's gone
+	got, err = db.Get(key)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestPebbleDBBatch(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Create a batch
+	batch := db.NewBatch()
+	require.NotNil(t, batch)
+
+	// Add operations to batch
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("batchkey%d", i))
+		value := []byte(fmt.Sprintf("batchvalue%d", i))
+		err = batch.Set(key, value)
+		require.NoError(t, err)
+	}
+
+	// Write batch
+	err = batch.WriteSync()
+	require.NoError(t, err)
+
+	// Verify all keys were written
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("batchkey%d", i))
+		expectedValue := []byte(fmt.Sprintf("batchvalue%d", i))
+		got, err := db.Get(key)
+		require.NoError(t, err)
+		assert.Equal(t, expectedValue, got)
+	}
+}
+
+func TestPebbleDBIterator(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Write test data
+	keys := []string{"a", "b", "c", "d", "e"}
+	for _, k := range keys {
+		err = db.Set([]byte(k), []byte("value_"+k))
+		require.NoError(t, err)
+	}
+
+	// Test forward iteration
+	itr, err := db.Iterator([]byte("b"), []byte("e"))
+	require.NoError(t, err)
+	defer itr.Close()
+
+	expected := []string{"b", "c", "d"}
+	i := 0
+	for ; itr.Valid(); itr.Next() {
+		assert.Equal(t, []byte(expected[i]), itr.Key())
+		i++
+	}
+	assert.Equal(t, len(expected), i)
+
+	// Test reverse iteration
+	ritr, err := db.ReverseIterator([]byte("b"), []byte("e"))
+	require.NoError(t, err)
+	defer ritr.Close()
+
+	expectedReverse := []string{"d", "c", "b"}
+	i = 0
+	for ; ritr.Valid(); ritr.Next() {
+		assert.Equal(t, []byte(expectedReverse[i]), ritr.Key())
+		i++
+	}
+	assert.Equal(t, len(expectedReverse), i)
+}

--- a/pebble_test.go
+++ b/pebble_test.go
@@ -50,35 +50,3 @@ func TestPebbleDBNewPebbleDB(t *testing.T) {
 	_, err = NewPebbleDB(name, "")
 	require.Error(t, err, "should not be able to open db twice")
 }
-
-func TestPebbleDBCompact(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, PebbleDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	// Write some data
-	for i := 0; i < 100; i++ {
-		key := []byte(fmt.Sprintf("key%03d", i))
-		value := []byte(fmt.Sprintf("value%03d", i))
-		err = db.Set(key, value)
-		require.NoError(t, err)
-	}
-
-	// Test compaction with nil start and end
-	err = db.Compact(nil, nil)
-	require.NoError(t, err)
-
-	// Test compaction with specific range
-	err = db.Compact([]byte("key000"), []byte("key050"))
-	require.NoError(t, err)
-
-	// Verify data is still accessible after compaction
-	value, err := db.Get([]byte("key025"))
-	require.NoError(t, err)
-	assert.Equal(t, []byte("value025"), value)
-}

--- a/pebble_test.go
+++ b/pebble_test.go
@@ -44,10 +44,11 @@ func TestPebbleDBNewPebbleDB(t *testing.T) {
 	// Test we can't open the db twice for writing
 	wr1, err := NewPebbleDB(name, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, wr1.Close())
+	})
 	_, err = NewPebbleDB(name, "")
 	require.Error(t, err, "should not be able to open db twice")
-	err = wr1.Close()
-	require.NoError(t, err)
 }
 
 func TestPebbleDBCompact(t *testing.T) {
@@ -80,115 +81,4 @@ func TestPebbleDBCompact(t *testing.T) {
 	value, err := db.Get([]byte("key025"))
 	require.NoError(t, err)
 	assert.Equal(t, []byte("value025"), value)
-}
-
-func TestPebbleDBDeleteSync(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, PebbleDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	// Set a key
-	key := []byte("testkey")
-	value := []byte("testvalue")
-	err = db.SetSync(key, value)
-	require.NoError(t, err)
-
-	// Verify it exists
-	got, err := db.Get(key)
-	require.NoError(t, err)
-	assert.Equal(t, value, got)
-
-	// Delete it synchronously
-	err = db.DeleteSync(key)
-	require.NoError(t, err)
-
-	// Verify it's gone
-	got, err = db.Get(key)
-	require.NoError(t, err)
-	assert.Nil(t, got)
-}
-
-func TestPebbleDBBatch(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, PebbleDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	// Create a batch
-	batch := db.NewBatch()
-	require.NotNil(t, batch)
-
-	// Add operations to batch
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("batchkey%d", i))
-		value := []byte(fmt.Sprintf("batchvalue%d", i))
-		err = batch.Set(key, value)
-		require.NoError(t, err)
-	}
-
-	// Write batch
-	err = batch.WriteSync()
-	require.NoError(t, err)
-
-	// Verify all keys were written
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("batchkey%d", i))
-		expectedValue := []byte(fmt.Sprintf("batchvalue%d", i))
-		got, err := db.Get(key)
-		require.NoError(t, err)
-		assert.Equal(t, expectedValue, got)
-	}
-}
-
-func TestPebbleDBIterator(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, PebbleDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	// Write test data
-	keys := []string{"a", "b", "c", "d", "e"}
-	for _, k := range keys {
-		err = db.Set([]byte(k), []byte("value_"+k))
-		require.NoError(t, err)
-	}
-
-	// Test forward iteration
-	itr, err := db.Iterator([]byte("b"), []byte("e"))
-	require.NoError(t, err)
-	defer itr.Close()
-
-	expected := []string{"b", "c", "d"}
-	i := 0
-	for ; itr.Valid(); itr.Next() {
-		assert.Equal(t, []byte(expected[i]), itr.Key())
-		i++
-	}
-	assert.Equal(t, len(expected), i)
-
-	// Test reverse iteration
-	ritr, err := db.ReverseIterator([]byte("b"), []byte("e"))
-	require.NoError(t, err)
-	defer ritr.Close()
-
-	expectedReverse := []string{"d", "c", "b"}
-	i = 0
-	for ; ritr.Valid(); ritr.Next() {
-		assert.Equal(t, []byte(expectedReverse[i]), ritr.Key())
-		i++
-	}
-	assert.Equal(t, len(expectedReverse), i)
 }

--- a/pebble_test.go
+++ b/pebble_test.go
@@ -55,7 +55,10 @@ func TestPebbleDBCompact(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, PebbleDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Write some data
 	for i := 0; i < 100; i++ {
@@ -84,7 +87,10 @@ func TestPebbleDBDeleteSync(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, PebbleDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Set a key
 	key := []byte("testkey")
@@ -112,7 +118,10 @@ func TestPebbleDBBatch(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, PebbleDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Create a batch
 	batch := db.NewBatch()
@@ -145,7 +154,10 @@ func TestPebbleDBIterator(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, PebbleDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Write test data
 	keys := []string{"a", "b", "c", "d", "e"}

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -40,13 +40,14 @@ func TestRocksDBNewRocksDB(t *testing.T) {
 	// Test we can't open the db twice for writing
 	wr1, err := NewRocksDB(name, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, wr1.Close())
+	})
 	_, err = NewRocksDB(name, "")
 	require.Error(t, err, "should not be able to open db twice")
-	err = wr1.Close()
-	require.NoError(t, err)
 }
 
-func TestRocksDBDeleteSync(t *testing.T) {
+func TestRocksDBCompact(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
@@ -56,109 +57,22 @@ func TestRocksDBDeleteSync(t *testing.T) {
 		cleanupDBDir(dir, name)
 	}()
 
-	// Set a key
-	key := []byte("testkey")
-	value := []byte("testvalue")
-	err = db.SetSync(key, value)
-	require.NoError(t, err)
-
-	// Verify it exists
-	got, err := db.Get(key)
-	require.NoError(t, err)
-	assert.Equal(t, value, got)
-
-	// Delete it synchronously
-	err = db.DeleteSync(key)
-	require.NoError(t, err)
-
-	// Verify it's gone
-	got, err = db.Get(key)
-	require.NoError(t, err)
-	assert.Nil(t, got)
-
-	// Test DeleteSync with empty key
-	err = db.DeleteSync([]byte{})
-	require.Error(t, err, "should error on empty key")
-}
-
-func TestRocksDBBatch(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, RocksDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	// Create a batch
-	batch := db.NewBatch()
-	require.NotNil(t, batch)
-
-	// Add operations to batch
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("batchkey%d", i))
-		value := []byte(fmt.Sprintf("batchvalue%d", i))
-		err = batch.Set(key, value)
+	for i := 0; i < 100; i++ {
+		key := []byte(fmt.Sprintf("key%03d", i))
+		value := []byte(fmt.Sprintf("value%03d", i))
+		err = db.Set(key, value)
 		require.NoError(t, err)
 	}
 
-	// Write batch
-	err = batch.WriteSync()
+	err = db.Compact(nil, nil)
 	require.NoError(t, err)
 
-	// Verify all keys were written
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("batchkey%d", i))
-		expectedValue := []byte(fmt.Sprintf("batchvalue%d", i))
-		got, err := db.Get(key)
-		require.NoError(t, err)
-		assert.Equal(t, expectedValue, got)
-	}
-}
-
-func TestRocksDBIterator(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, RocksDBBackend, dir)
+	err = db.Compact([]byte("key000"), []byte("key050"))
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
 
-	// Write test data
-	keys := []string{"a", "b", "c", "d", "e"}
-	for _, k := range keys {
-		err = db.Set([]byte(k), []byte("value_"+k))
-		require.NoError(t, err)
-	}
-
-	// Test forward iteration
-	itr, err := db.Iterator([]byte("b"), []byte("e"))
+	value, err := db.Get([]byte("key025"))
 	require.NoError(t, err)
-	defer itr.Close()
-
-	expected := []string{"b", "c", "d"}
-	i := 0
-	for ; itr.Valid(); itr.Next() {
-		assert.Equal(t, []byte(expected[i]), itr.Key())
-		i++
-	}
-	assert.Equal(t, len(expected), i)
-
-	// Test reverse iteration
-	ritr, err := db.ReverseIterator([]byte("b"), []byte("e"))
-	require.NoError(t, err)
-	defer ritr.Close()
-
-	expectedReverse := []string{"d", "c", "b"}
-	i = 0
-	for ; ritr.Valid(); ritr.Next() {
-		assert.Equal(t, []byte(expectedReverse[i]), ritr.Key())
-		i++
-	}
-	assert.Equal(t, len(expectedReverse), i)
+	assert.Equal(t, []byte("value025"), value)
 }
 
 func BenchmarkRocksDBRandomReadsWrites(b *testing.B) {

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -33,4 +33,136 @@ func TestRocksDBStats(t *testing.T) {
 	assert.NotEmpty(t, db.Stats())
 }
 
-// TODO: Add tests for rocksdb
+func TestRocksDBNewRocksDB(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	defer cleanupDBDir("", name)
+
+	// Test we can't open the db twice for writing
+	wr1, err := NewRocksDB(name, "")
+	require.NoError(t, err)
+	_, err = NewRocksDB(name, "")
+	require.Error(t, err, "should not be able to open db twice")
+	err = wr1.Close()
+	require.NoError(t, err)
+}
+
+func TestRocksDBDeleteSync(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, RocksDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Set a key
+	key := []byte("testkey")
+	value := []byte("testvalue")
+	err = db.SetSync(key, value)
+	require.NoError(t, err)
+
+	// Verify it exists
+	got, err := db.Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, value, got)
+
+	// Delete it synchronously
+	err = db.DeleteSync(key)
+	require.NoError(t, err)
+
+	// Verify it's gone
+	got, err = db.Get(key)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Test DeleteSync with empty key
+	err = db.DeleteSync([]byte{})
+	require.Error(t, err, "should error on empty key")
+}
+
+func TestRocksDBBatch(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, RocksDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Create a batch
+	batch := db.NewBatch()
+	require.NotNil(t, batch)
+
+	// Add operations to batch
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("batchkey%d", i))
+		value := []byte(fmt.Sprintf("batchvalue%d", i))
+		err = batch.Set(key, value)
+		require.NoError(t, err)
+	}
+
+	// Write batch
+	err = batch.WriteSync()
+	require.NoError(t, err)
+
+	// Verify all keys were written
+	for i := 0; i < 10; i++ {
+		key := []byte(fmt.Sprintf("batchkey%d", i))
+		expectedValue := []byte(fmt.Sprintf("batchvalue%d", i))
+		got, err := db.Get(key)
+		require.NoError(t, err)
+		assert.Equal(t, expectedValue, got)
+	}
+}
+
+func TestRocksDBIterator(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, RocksDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	// Write test data
+	keys := []string{"a", "b", "c", "d", "e"}
+	for _, k := range keys {
+		err = db.Set([]byte(k), []byte("value_"+k))
+		require.NoError(t, err)
+	}
+
+	// Test forward iteration
+	itr, err := db.Iterator([]byte("b"), []byte("e"))
+	require.NoError(t, err)
+	defer itr.Close()
+
+	expected := []string{"b", "c", "d"}
+	i := 0
+	for ; itr.Valid(); itr.Next() {
+		assert.Equal(t, []byte(expected[i]), itr.Key())
+		i++
+	}
+	assert.Equal(t, len(expected), i)
+
+	// Test reverse iteration
+	ritr, err := db.ReverseIterator([]byte("b"), []byte("e"))
+	require.NoError(t, err)
+	defer ritr.Close()
+
+	expectedReverse := []string{"d", "c", "b"}
+	i = 0
+	for ; ritr.Valid(); ritr.Next() {
+		assert.Equal(t, []byte(expectedReverse[i]), ritr.Key())
+		i++
+	}
+	assert.Equal(t, len(expectedReverse), i)
+}
+
+func BenchmarkRocksDBRandomReadsWrites(b *testing.B) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	db, err := NewRocksDB(name, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		err = db.Close()
+		require.NoError(b, err)
+		cleanupDBDir("", name)
+	}()
+
+	benchmarkRandomReadsWrites(b, db)
+}

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -51,7 +51,10 @@ func TestRocksDBDeleteSync(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Set a key
 	key := []byte("testkey")
@@ -83,7 +86,10 @@ func TestRocksDBBatch(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Create a batch
 	batch := db.NewBatch()
@@ -116,7 +122,10 @@ func TestRocksDBIterator(t *testing.T) {
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
+	defer func() {
+		require.NoError(t, db.Close())
+		cleanupDBDir(dir, name)
+	}()
 
 	// Write test data
 	keys := []string{"a", "b", "c", "d", "e"}

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -47,34 +47,6 @@ func TestRocksDBNewRocksDB(t *testing.T) {
 	require.Error(t, err, "should not be able to open db twice")
 }
 
-func TestRocksDBCompact(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db, err := NewDB(name, RocksDBBackend, dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-		cleanupDBDir(dir, name)
-	}()
-
-	for i := 0; i < 100; i++ {
-		key := []byte(fmt.Sprintf("key%03d", i))
-		value := []byte(fmt.Sprintf("value%03d", i))
-		err = db.Set(key, value)
-		require.NoError(t, err)
-	}
-
-	err = db.Compact(nil, nil)
-	require.NoError(t, err)
-
-	err = db.Compact([]byte("key000"), []byte("key050"))
-	require.NoError(t, err)
-
-	value, err := db.Get([]byte("key025"))
-	require.NoError(t, err)
-	assert.Equal(t, []byte("value025"), value)
-}
-
 func BenchmarkRocksDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	db, err := NewRocksDB(name, "")


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds focused tests to harden DB backends.
> 
> - Extend `backend_test.go` to verify range `Compact(start,end)` works and preserves data, plus pebble-specific cleanup wait
> - New `TestPebbleDBNewPebbleDB` and `TestRocksDBNewRocksDB` to assert databases cannot be opened twice for writing
> - Add `BenchmarkRocksDBRandomReadsWrites`; keep existing Pebble benchmark and backend type assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d0bfa1b4335455b697727becaa92fb655cbdb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->