### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cosmos/stack-team
+** @cometbft/stack-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-*   @CometBFT/engineering @cometbft/interchain-inc
+* @cosmos/stack-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@cometbft/stack-team` as code owners for all files.