### PR TITLE
perf(goleveldb): use LevelDB Has to skip value reads

### DIFF
--- a/goleveldb.go
+++ b/goleveldb.go
@@ -57,11 +57,10 @@ func (db *GoLevelDB) Get(key []byte) ([]byte, error) {
 
 // Has implements DB.
 func (db *GoLevelDB) Has(key []byte) (bool, error) {
-	bytes, err := db.Get(key)
-	if err != nil {
-		return false, err
+	if len(key) == 0 {
+		return false, errKeyEmpty
 	}
-	return bytes != nil, nil
+	return db.db.Has(key, nil)
 }
 
 // Set implements DB.

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -9,11 +9,13 @@ RUN apt update \
 ARG ROCKSDB=9.8.4
 
 # Install RocksDB
+# GCC 12 reports false-positive uninitialized warnings from its AVX-512
+# intrinsic headers while compiling RocksDB's bundled xxHash implementation.
 RUN \
   wget -q https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB}.tar.gz \
   && tar -zxf v${ROCKSDB}.tar.gz \
   && cd rocksdb-${ROCKSDB} \
-  && DEBUG_LEVEL=0 CXXFLAGS="-Wno-maybe-uninitialized" make -j4 shared_lib \
+  && DEBUG_LEVEL=0 CXXFLAGS="-Wno-maybe-uninitialized -Wno-error=uninitialized" make -j4 shared_lib \
   && make install-shared \
   && ldconfig \
   && cd .. \


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

-->
Replace `Get()` call with native LevelDB `Has()` method to check key existence without reading the value data. 
This reduces I/O and memory overhead for `Has()` operations.

the same https://github.com/cosmos/cosmos-db/pull/145

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
